### PR TITLE
Minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,29 @@ To run integration tests:
 go test -v -tags=integration ./...
 ```
 
+## Tools used
+
+- [Go 1.24](https://golang.org)
+- [PokeAPI](https://pokeapi.co) as the main data source
+- [Testify](https://pkg.go.dev/github.com/stretchr/testify) for assertions
+- [QucikType](https://app.quicktype.io/) for generating API structs
+- [Ristretto](https://github.com/dgraph-io/ristretto) for caching
+
+## Design Philosophy
+
+The SDK was designed to be simple but extensible. For a client of this type
+a flat structure was chosen, with just a few internals (cache and api types). This
+keeps things simple, while also being testable.
+
+The API types being in a non-importable package allows us to cleary define 
+the boundaries between what is the raw data types from the API, and what is the 
+public objects we want to expose to consumers (which are not just the plain API response, but
+are enriched to provide a better user experience).
+
+When multiple requests are involved (such as fetching list resource), concurrency
+was chosen to avoid requests taking too long. Our rate limiting logic should ensure that we are not 
+overloading the API.
+
 ## Future Improvements
 
 * Tweak rate limiting
@@ -126,3 +149,4 @@ go test -v -tags=integration ./...
 client rather than on each method
 * Create a test server that can handle all requests
 * Add fun methods to pokemon (e.g. `pokemon.canBeat(otherPokemon)`)
+* Configurable parameters for fetching results

--- a/client.go
+++ b/client.go
@@ -138,7 +138,7 @@ func (c *Client) Get(ctx context.Context, path string, response any) error {
 
 // FetchResults fetches all resources from the given list sequentially.
 // It makes individual API calls for each resource URL and returns the results.
-func FetchResults[T any](ctx context.Context, c *Client, l []Resource) ([]T, error) {
+func fetchResults[T any](ctx context.Context, c *Client, l []Resource) ([]T, error) {
 	results := make([]T, 0, len(l))
 	for _, result := range l {
 		var resp T
@@ -154,7 +154,7 @@ func FetchResults[T any](ctx context.Context, c *Client, l []Resource) ([]T, err
 
 // FetchResultsN fetches all resources from the given list concurrently using n workers.
 // It's more efficient than FetchResults for large lists but uses more resources.
-func FetchResultsN[T any](ctx context.Context, c *Client, l []Resource, n int) ([]T, error) {
+func fetchResultsN[T any](ctx context.Context, c *Client, l []Resource, n int) ([]T, error) {
 	if n < 1 {
 		n = 1
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -1,7 +1,6 @@
 package pokeapi_test
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -12,108 +11,6 @@ import (
 
 	"github.com/tgmendes/pokeapi-sdk"
 )
-
-func TestList_FetchResults(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {
-			res := pokeapi.Pokemon{}
-
-			err := json.NewEncoder(w).Encode(&res)
-			require.NoError(t, err)
-		},
-	))
-	defer srv.Close()
-
-	l := []pokeapi.Resource{
-		{
-			Name: "bulbasaur",
-			URL:  "/pokemon/1",
-		},
-		{
-			Name: "ivysaur",
-			URL:  "/pokemon/1",
-		},
-		{
-			Name: "venusaur",
-			URL:  "/pokemon/1",
-		},
-	}
-
-	client, err := pokeapi.NewClient(srv.URL)
-	require.NoError(t, err)
-
-	res, err := pokeapi.FetchResults[pokeapi.Pokemon](t.Context(), client, l)
-	require.NoError(t, err)
-
-	assert.Len(t, res, 3)
-}
-
-func TestList_FetchResultsN(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {
-			res := pokeapi.Pokemon{}
-
-			err := json.NewEncoder(w).Encode(&res)
-			require.NoError(t, err)
-		},
-	))
-	defer srv.Close()
-
-	l := []pokeapi.Resource{
-		{
-			Name: "bulbasaur",
-			URL:  "/pokemon/1",
-		},
-		{
-			Name: "ivysaur",
-			URL:  "/pokemon/1",
-		},
-		{
-			Name: "venusaur",
-			URL:  "/pokemon/1",
-		},
-		{
-			Name: "ivysaur",
-			URL:  "/pokemon/1",
-		},
-		{
-			Name: "venusaur",
-			URL:  "/pokemon/1",
-		},
-		{
-			Name: "ivysaur",
-			URL:  "/pokemon/1",
-		},
-		{
-			Name: "venusaur",
-			URL:  "/pokemon/1",
-		},
-		{
-			Name: "ivysaur",
-			URL:  "/pokemon/1",
-		},
-		{
-			Name: "venusaur",
-			URL:  "/pokemon/1",
-		},
-		{
-			Name: "ivysaur",
-			URL:  "/pokemon/1",
-		},
-		{
-			Name: "venusaur",
-			URL:  "/pokemon/1",
-		},
-	}
-
-	client, err := pokeapi.NewClient(srv.URL)
-	require.NoError(t, err)
-
-	res, err := pokeapi.FetchResultsN[pokeapi.Pokemon](t.Context(), client, l, 4)
-	require.NoError(t, err)
-
-	assert.Len(t, res, 11)
-}
 
 func TestClient_Error(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(

--- a/cmd/example.go
+++ b/cmd/example.go
@@ -27,12 +27,12 @@ func main() {
 	fmt.Printf("Pokémon: %s (ID: %d)\n", pokemon.Name, pokemon.ID)
 
 	// get all pokemon
-	allPokemon, _ := client.AllPokemon(context.Background())
-
-	fmt.Printf("Total pokemon: %d\n", len(allPokemon))
-	fmt.Printf("First Pokémon: %s (ID: %d)\n", allPokemon[0].Name, allPokemon[0].ID)
-	fmt.Printf("Last Pokémon: %s (ID: %d)\n",
-		allPokemon[len(allPokemon)-1].Name, allPokemon[len(allPokemon)-1].ID)
+	//allPokemon, _ := client.AllPokemon(context.Background())
+	//
+	//fmt.Printf("Total pokemon: %d\n", len(allPokemon))
+	//fmt.Printf("First Pokémon: %s (ID: %d)\n", allPokemon[0].Name, allPokemon[0].ID)
+	//fmt.Printf("Last Pokémon: %s (ID: %d)\n",
+	//	allPokemon[len(allPokemon)-1].Name, allPokemon[len(allPokemon)-1].ID)
 
 	// get generation by id
 	generation, _ := client.GenerationByID(context.Background(), 1)
@@ -52,16 +52,17 @@ func main() {
 	// paginating
 	pager := client.PokemonPager(pokeapi.Limit(50))
 	firstPage, _ := pager.Next(context.Background())
-	res, _ := pokeapi.FetchResultsN[pokeapi.Pokemon](context.Background(), client, firstPage, 5)
+	res, _ := client.ParsePokemonResource(context.Background(), firstPage)
 	fmt.Printf("First Pokemon: %s\n", res[0].Name)
+	fmt.Printf("First Pokemon Moves: %v\n", res[0].Moves)
 
 	// next page
 	secondPage, _ := pager.Next(context.Background())
-	res, _ = pokeapi.FetchResultsN[pokeapi.Pokemon](context.Background(), client, secondPage, 5)
+	res, _ = client.ParsePokemonResource(context.Background(), secondPage)
 	fmt.Printf("Second Pokemon: %s\n", res[0].Name)
 
 	// previous page
 	previousPage, _ := pager.Previous(context.Background())
-	res, _ = pokeapi.FetchResultsN[pokeapi.Pokemon](context.Background(), client, previousPage, 5)
+	res, _ = client.ParsePokemonResource(context.Background(), previousPage)
 	fmt.Printf("Previous Pokemon: %s\n", res[0].Name)
 }

--- a/generation.go
+++ b/generation.go
@@ -70,7 +70,7 @@ func (c *Client) AllGenerations(ctx context.Context, options ...RequestOption) (
 			return nil, err
 		}
 
-		apiGenerations, err := FetchResultsN[apitype.Generation](ctx, c, list, 5)
+		apiGenerations, err := fetchResultsN[apitype.Generation](ctx, c, list, 5)
 		if err != nil {
 			return nil, err
 		}
@@ -117,6 +117,26 @@ func (c *Client) GenerationPager(options ...RequestOption) *Pager {
 	return NewPager(c, startPath)
 }
 
+// ParseGenerationResource takes a list of pagination resources and converts them into
+// a list of generations.
+func (c *Client) ParseGenerationResource(ctx context.Context, resource []Resource) ([]Generation, error) {
+	apiGenerations, err := fetchResultsN[apitype.Generation](ctx, c, resource, 5)
+	if err != nil {
+		return nil, err
+	}
+
+	generations := make([]Generation, 0, len(apiGenerations))
+	for _, apiGeneration := range apiGenerations {
+		generation, err := c.mapGeneration(ctx, apiGeneration)
+		if err != nil {
+			return nil, err
+		}
+		generations = append(generations, *generation)
+	}
+
+	return generations, nil
+}
+
 func (c *Client) mapGeneration(ctx context.Context, gen apitype.Generation) (*Generation, error) {
 	moves := make([]string, 0, len(gen.Moves))
 	for _, move := range gen.Moves {
@@ -138,7 +158,7 @@ func (c *Client) mapGeneration(ctx context.Context, gen apitype.Generation) (*Ge
 		URL:  gen.MainRegion.URL,
 	}
 
-	region, err := FetchResults[apitype.Region](ctx, c, []Resource{regionResource})
+	region, err := fetchResults[apitype.Region](ctx, c, []Resource{regionResource})
 	if err != nil {
 		return nil, err
 	}

--- a/generation_test.go
+++ b/generation_test.go
@@ -129,6 +129,22 @@ func TestGenerationPager(t *testing.T) {
 	}
 }
 
+func TestParseGenerationResource(t *testing.T) {
+	srv := setupGenerationServer(t)
+	defer srv.Close()
+
+	client, err := pokeapi.NewClient(srv.URL)
+	require.NoError(t, err)
+
+	page, err := client.GenerationPage(t.Context())
+	require.NoError(t, err)
+
+	generations, err := client.ParseGenerationResource(t.Context(), page)
+	require.NoError(t, err)
+	require.NotNil(t, generations)
+	assert.Len(t, generations, 9)
+}
+
 func setupGenerationServer(t *testing.T) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+////go:build integration
 
 package pokeapi_test
 
@@ -42,6 +42,22 @@ func TestAllPokemon_Integration(t *testing.T) {
 	assert.Equal(t, "bulbasaur", pokemon[0].Name)
 }
 
+func TestPokemonPage_Integration(t *testing.T) {
+	client, err := pokeapi.NewClient("https://pokeapi.co/api/v2",
+		pokeapi.WithLimit(2000, 2000))
+	require.NoError(t, err)
+
+	page, err := client.PokemonPage(t.Context(),
+		pokeapi.Limit(10), pokeapi.Offset(20))
+	require.NoError(t, err)
+
+	results, err := client.ParsePokemonResource(t.Context(), page)
+	require.NoError(t, err)
+	assert.Len(t, results, 10)
+	assert.Equal(t, 21, results[0].ID)
+	assert.Equal(t, "spearow", results[0].Name)
+}
+
 func TestGenerationByID_Integration(t *testing.T) {
 	client, err := pokeapi.NewClient("https://pokeapi.co/api/v2")
 
@@ -68,4 +84,19 @@ func TestAllGeneration_Integration(t *testing.T) {
 	assert.Len(t, generation, 9)
 	assert.Equal(t, 1, generation[0].ID)
 	assert.Equal(t, "generation-i", generation[0].Name)
+}
+
+func TestGenerationPage_Integration(t *testing.T) {
+	client, err := pokeapi.NewClient("https://pokeapi.co/api/v2",
+		pokeapi.WithLimit(2000, 2000))
+	require.NoError(t, err)
+
+	page, err := client.GenerationPage(t.Context())
+	require.NoError(t, err)
+
+	results, err := client.ParseGenerationResource(t.Context(), page)
+	require.NoError(t, err)
+	assert.Len(t, results, 9)
+	assert.Equal(t, 1, results[0].ID)
+	assert.Equal(t, "generation-i", results[0].Name)
 }

--- a/pokemon.go
+++ b/pokemon.go
@@ -81,18 +81,9 @@ func (c *Client) AllPokemon(ctx context.Context, options ...RequestOption) ([]Po
 			return nil, err
 		}
 
-		apiPokemons, err := FetchResultsN[apitype.Pokemon](ctx, c, list, 5)
+		pokemons, err := c.ParsePokemonResource(ctx, list)
 		if err != nil {
 			return nil, err
-		}
-
-		pokemons := make([]Pokemon, 0, len(apiPokemons))
-		for _, apiPokemon := range apiPokemons {
-			pokemon, err := c.mapPokemon(ctx, apiPokemon)
-			if err != nil {
-				return nil, err
-			}
-			pokemons = append(pokemons, *pokemon)
 		}
 
 		results = append(results, pokemons...)
@@ -128,6 +119,24 @@ func (c *Client) PokemonPager(options ...RequestOption) *Pager {
 	return NewPager(c, startPath)
 }
 
+func (c *Client) ParsePokemonResource(ctx context.Context, resource []Resource) ([]Pokemon, error) {
+	apiPokemons, err := fetchResultsN[apitype.Pokemon](ctx, c, resource, 5)
+	if err != nil {
+		return nil, err
+	}
+
+	pokemons := make([]Pokemon, 0, len(apiPokemons))
+	for _, apiPokemon := range apiPokemons {
+		pokemon, err := c.mapPokemon(ctx, apiPokemon)
+		if err != nil {
+			return nil, err
+		}
+		pokemons = append(pokemons, *pokemon)
+	}
+
+	return pokemons, nil
+}
+
 func (c *Client) mapPokemon(ctx context.Context, poke apitype.Pokemon) (*Pokemon, error) {
 	movesResource := make([]Resource, 0, len(poke.Moves))
 	for _, move := range poke.Moves {
@@ -137,7 +146,7 @@ func (c *Client) mapPokemon(ctx context.Context, poke apitype.Pokemon) (*Pokemon
 		})
 	}
 
-	moves, err := FetchResultsN[apitype.Move](ctx, c, movesResource, 5)
+	moves, err := fetchResultsN[apitype.Move](ctx, c, movesResource, 5)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +156,7 @@ func (c *Client) mapPokemon(ctx context.Context, poke apitype.Pokemon) (*Pokemon
 		URL:  poke.Species.URL,
 	}
 
-	species, err := FetchResults[apitype.Species](ctx, c, []Resource{speciesResource})
+	species, err := fetchResults[apitype.Species](ctx, c, []Resource{speciesResource})
 	if err != nil {
 		return nil, err
 	}

--- a/pokemon_test.go
+++ b/pokemon_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestGetPokemonByName(t *testing.T) {
-	srv := setupServer(t)
+	srv := setupPokemonServer(t)
 	defer srv.Close()
 
 	client, err := pokeapi.NewClient(srv.URL)
@@ -29,7 +29,7 @@ func TestGetPokemonByName(t *testing.T) {
 }
 
 func TestGetPokemonByID(t *testing.T) {
-	srv := setupServer(t)
+	srv := setupPokemonServer(t)
 	defer srv.Close()
 
 	client, err := pokeapi.NewClient(srv.URL)
@@ -43,7 +43,7 @@ func TestGetPokemonByID(t *testing.T) {
 }
 
 func TestPokemonPage(t *testing.T) {
-	srv := setupServer(t)
+	srv := setupPokemonServer(t)
 	defer srv.Close()
 
 	client, err := pokeapi.NewClient(srv.URL)
@@ -57,7 +57,7 @@ func TestPokemonPage(t *testing.T) {
 }
 
 func TestAllPokemon(t *testing.T) {
-	srv := setupServer(t)
+	srv := setupPokemonServer(t)
 	defer srv.Close()
 
 	client, err := pokeapi.NewClient(srv.URL)
@@ -69,6 +69,24 @@ func TestAllPokemon(t *testing.T) {
 	assert.Len(t, pokemon, 40)
 	assert.Equal(t, pokemon[0].ID, 35)
 	assert.Equal(t, pokemon[0].Name, "clefairy")
+	assert.Len(t, pokemon[0].Moves, 1)
+}
+
+func TestParsePokemonResource(t *testing.T) {
+	srv := setupPokemonServer(t)
+	defer srv.Close()
+
+	client, err := pokeapi.NewClient(srv.URL)
+	require.NoError(t, err)
+
+	page, err := client.PokemonPage(t.Context())
+	require.NoError(t, err)
+
+	pokemons, err := client.ParsePokemonResource(t.Context(), page)
+	require.NoError(t, err)
+	require.NotNil(t, pokemons)
+	assert.Len(t, pokemons, 20)
+	assert.Len(t, pokemons[0].Moves, 1)
 }
 
 func TestPokemonPager(t *testing.T) {
@@ -126,7 +144,7 @@ func TestPokemonPager(t *testing.T) {
 	}
 }
 
-func setupServer(t *testing.T) *httptest.Server {
+func setupPokemonServer(t *testing.T) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			switch {


### PR DESCRIPTION
## Why?

The existing implementation of the pagination required consumers to call fetch directly, exposing an internal concern of the API. More importantly, it didn't allow consumers to properly parse api responses, as api types were unexported.

## What?

This PR adds utility methods to allow consumers to parse pokemons from listed resources.

